### PR TITLE
RecordParser optimized

### DIFF
--- a/[requested-optimizations]/MySqlBulkInsertExcel-Benchmark/Benchmark.cs
+++ b/[requested-optimizations]/MySqlBulkInsertExcel-Benchmark/Benchmark.cs
@@ -51,6 +51,9 @@ public class Benchmark()
     }
 
     [Benchmark]
+    public Task OriginalWithSpan() => ExcelProcessor.RunOriginalWithSpanAsync(GetStream(), "tag-name", dbContext);
+
+    [Benchmark]
     public Task Original() => ExcelProcessor.RunOriginalAsync(GetStream(), "tag-name", dbContext);
 
     [Benchmark]


### PR DESCRIPTION
Current implementation using RecordParser 's raw method is only recommended when user desires/must receive a string.
Other methods that does not force string uses `ReadOnlySpan<char>`, which speed up processing and reduces allocation.